### PR TITLE
Properly load css files

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <title>{{ site.title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#157878">
-  <link rel="stylesheet" href="/css/normalize.css">
+  <link rel="stylesheet" href="css/normalize.css">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="/css/cayman.css">
+  <link rel="stylesheet" href="css/cayman.css">
 </head>


### PR DESCRIPTION
Your theme doesn't correctly reference the css files that define the Cayman theme on some serve locations. For example, on the GitHub Pages location of the repository this PR comes from, http://debium.github.io/jekyll-cayman-theme/, this is what your code would produce:
![](https://cloud.githubusercontent.com/assets/16024539/13037411/0724561e-d346-11e5-9a45-9fc5eb5fd2be.png)

As it references the files, which don't exist, at
- http://debium.github.io/css/normalize.css
- http://debium.github.io/css/cayman.css

My solution relatively links the css, eliminating the chance of the oddities in some URLs from ruining the theming. Here is an image of my implementation:
![](https://cloud.githubusercontent.com/assets/16024539/13037485/1cd25974-d347-11e5-9925-058a74b592e4.png)

However, this doesn't fix #1.
Thanks for taking your time to review my patch! I hope it helps! :octocat:
