### PR TITLE
Fixes #1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ $ jekyll serve
 
 For more details read about [Jekyll][1] on its web page.
 
+# Setup
+
+Some important configuration can be done in file `_config.yml`. Please, chec the Setup setion in this file.
+
+
+## baseurl
+
+`baseurl` parameter is required in the case the site doesn't sit on the root of the domain. For example: http://pietromenna.github.io/jekyll-cayman-theme
+
+In the case above the baseurl should be set to "/jekyll-cayman-theme".
+
+In the case the site sits in the root, you can leave `baseurl` as empty "".
+
 # License
 
 This work is licensed under a [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/) license.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <title>{{ site.title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#157878">
-  <link rel="stylesheet" href="css/normalize.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="css/cayman.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/cayman.css">
 </head>


### PR DESCRIPTION
- baseurl is required for sites which do not sit on the root of the domain
