### PR TITLE
Fixes <html lang="en-us"> to be optionally overwritten

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="{{ site.locale | slice: 0,2 | default: "en" }}">
   
   {% include head.html %}
 


### PR DESCRIPTION
Fixes [accessibility] Allow `lang` attribute hardcored on `<html lang="en-us">` to be optionally overwritten #25 

Note, I haven't personally tested this. I copied it from another Jekyll theme.